### PR TITLE
SDK fixes for BL702 (EFUSE, USB, ADC, etc.)

### DIFF
--- a/components/usb/cherryusb/class/hid/usbd_hid.c
+++ b/components/usb/cherryusb/class/hid/usbd_hid.c
@@ -17,8 +17,7 @@ static int hid_class_interface_request_handler(struct usb_setup_packet *setup, u
     switch (setup->bRequest) {
         case HID_REQUEST_GET_REPORT:
             /* report id ,report type */
-            (*data)[0] = usbh_hid_get_report(intf_num, LO_BYTE(setup->wValue), HI_BYTE(setup->wValue));
-            *len = 1;
+			usbh_hid_get_report(intf_num, LO_BYTE(setup->wValue), HI_BYTE(setup->wValue), data, len);
             break;
         case HID_REQUEST_GET_IDLE:
             (*data)[0] = usbh_hid_get_idle(intf_num, LO_BYTE(setup->wValue));
@@ -61,7 +60,7 @@ struct usbd_interface *usbd_hid_init_intf(struct usbd_interface *intf, const uin
     return intf;
 }
 
-__WEAK uint8_t usbh_hid_get_report(uint8_t intf, uint8_t report_id, uint8_t report_type)
+__WEAK uint8_t usbh_hid_get_report(uint8_t intf, uint8_t report_id, uint8_t report_type, uint8_t **report, uint32_t *len)
 {
     return 0;
 }
@@ -76,7 +75,7 @@ __WEAK uint8_t usbh_hid_get_protocol(uint8_t intf)
     return 0;
 }
 
-__WEAK void usbh_hid_set_report(uint8_t intf, uint8_t report_id, uint8_t report_type, uint8_t *report, uint8_t report_len)
+__WEAK void usbh_hid_set_report(uint8_t intf, uint8_t report_id, uint8_t report_type, uint8_t *report, uint16_t report_len)
 {
 }
 

--- a/components/usb/cherryusb/class/hid/usbd_hid.h
+++ b/components/usb/cherryusb/class/hid/usbd_hid.h
@@ -20,10 +20,10 @@ void usbd_hid_descriptor_register(uint8_t intf_num, const uint8_t *desc);
 void usbd_hid_report_descriptor_register(uint8_t intf_num, const uint8_t *desc, uint32_t desc_len);
 
 /* Setup request command callback api */
-uint8_t usbh_hid_get_report(uint8_t intf, uint8_t report_id, uint8_t report_type);
+uint8_t usbh_hid_get_report(uint8_t intf, uint8_t report_id, uint8_t report_type, uint8_t **report, uint32_t *len);
 uint8_t usbh_hid_get_idle(uint8_t intf, uint8_t report_id);
 uint8_t usbh_hid_get_protocol(uint8_t intf);
-void usbh_hid_set_report(uint8_t intf, uint8_t report_id, uint8_t report_type, uint8_t *report, uint8_t report_len);
+void usbh_hid_set_report(uint8_t intf, uint8_t report_id, uint8_t report_type, uint8_t *report, uint16_t report_len);
 void usbh_hid_set_idle(uint8_t intf, uint8_t report_id, uint8_t duration);
 void usbh_hid_set_protocol(uint8_t intf, uint8_t protocol);
 

--- a/drivers/lhal/include/bflb_adc.h
+++ b/drivers/lhal/include/bflb_adc.h
@@ -40,6 +40,7 @@
 /** @defgroup ADC_CLK_DIV adc clock divison definition
   * @{
   */
+#define ADC_CLK_DIV_1  0
 #define ADC_CLK_DIV_4  1
 #define ADC_CLK_DIV_8  2
 #define ADC_CLK_DIV_12 3

--- a/drivers/lhal/include/bflb_adc.h
+++ b/drivers/lhal/include/bflb_adc.h
@@ -184,7 +184,7 @@ void bflb_adc_link_rxdma(struct bflb_device_s *dev, bool enable);
  * @param [in] channels pair number of channels
  * @return Zero on success; a negated errno value on failure
  */
-int bflb_adc_channel_config(struct bflb_device_s *dev, struct bflb_adc_channel_s *chan, uint8_t channels);
+int bflb_adc_channel_config(struct bflb_device_s *dev, const struct bflb_adc_channel_s *chan, uint8_t channels);
 
 /**
  * @brief Start adc conversion

--- a/drivers/lhal/include/bflb_mtimer.h
+++ b/drivers/lhal/include/bflb_mtimer.h
@@ -50,14 +50,14 @@ void bflb_mtimer_delay_us(uint32_t time);
  *
  * @return time with us
  */
-uint64_t bflb_mtimer_get_time_us();
+uint64_t bflb_mtimer_get_time_us(void);
 
 /**
  * @brief Get current mtimer time with ms.
  *
  * @return time with ms
  */
-uint64_t bflb_mtimer_get_time_ms();
+uint64_t bflb_mtimer_get_time_ms(void);
 
 #ifdef __cplusplus
 }

--- a/drivers/lhal/include/bflb_pwm_v1.h
+++ b/drivers/lhal/include/bflb_pwm_v1.h
@@ -1,5 +1,5 @@
 #ifndef _BFLB_PWM_V1_H
-#define _BFLB_PWM_V2_H
+#define _BFLB_PWM_V1_H
 
 #include "bflb_core.h"
 

--- a/drivers/lhal/src/bflb_adc.c
+++ b/drivers/lhal/src/bflb_adc.c
@@ -195,7 +195,7 @@ void bflb_adc_link_rxdma(struct bflb_device_s *dev, bool enable)
     putreg32(regval, ADC_GPIP_BASE + GPIP_GPADC_CONFIG_OFFSET);
 }
 
-int bflb_adc_channel_config(struct bflb_device_s *dev, struct bflb_adc_channel_s *chan, uint8_t channels)
+int bflb_adc_channel_config(struct bflb_device_s *dev, const struct bflb_adc_channel_s *chan, uint8_t channels)
 {
     uint32_t regval;
     uint32_t regval2;
@@ -462,21 +462,21 @@ void bflb_adc_parse_result(struct bflb_device_s *dev, uint32_t *buffer, struct b
                     conv_result = 4095;
                 }
                 result[i].value = conv_result;
-                result[i].millivolt = (float)result[i].value / 4096 * ref;
+                result[i].millivolt = (float)result[i].value / 4095.0f * ref;
             } else if (resolution == ADC_RESOLUTION_14B) {
                 conv_result = (uint32_t)(((buffer[i] & 0xffff) >> 2) / coe);
                 if (conv_result > 16383) {
                     conv_result = 16383;
                 }
                 result[i].value = conv_result;
-                result[i].millivolt = (float)result[i].value / 16384 * ref;
+                result[i].millivolt = (float)result[i].value / 16383.0f * ref;
             } else if (resolution == ADC_RESOLUTION_16B) {
                 conv_result = (uint32_t)((buffer[i] & 0xffff) / coe);
                 if (conv_result > 65535) {
                     conv_result = 65535;
                 }
                 result[i].value = conv_result;
-                result[i].millivolt = (int32_t)result[i].value / 65536.0 * ref;
+                result[i].millivolt = (int32_t)result[i].value / 65535.0f * ref;
             } else {
             }
         }
@@ -499,21 +499,21 @@ void bflb_adc_parse_result(struct bflb_device_s *dev, uint32_t *buffer, struct b
                     conv_result = 2047;
                 }
                 result[i].value = conv_result;
-                result[i].millivolt = (float)result[i].value / 2048 * ref;
+                result[i].millivolt = (float)result[i].value / 2047 * ref;
             } else if (resolution == ADC_RESOLUTION_14B) {
                 conv_result = (uint32_t)(((tmp & 0xffff) >> 2) / coe);
                 if (conv_result > 8191) {
                     conv_result = 8191;
                 }
                 result[i].value = conv_result;
-                result[i].millivolt = (float)result[i].value / 8192 * ref;
+                result[i].millivolt = (float)result[i].value / 8191 * ref;
             } else if (resolution == ADC_RESOLUTION_16B) {
                 conv_result = (uint32_t)((tmp & 0xffff) / coe);
                 if (conv_result > 32767) {
                     conv_result = 32767;
                 }
                 result[i].value = conv_result;
-                result[i].millivolt = (float)result[i].value / 32768 * ref;
+                result[i].millivolt = (float)result[i].value / 32767 * ref;
             } else {
             }
 
@@ -613,9 +613,9 @@ float bflb_adc_tsen_get_temp(struct bflb_device_s *dev)
     bflb_adc_parse_result(dev, &raw_data, &result, 1);
     v1 = result.value;
     if (v0 > v1) {
-        temp = (((float)v0 - (float)v1) - (float)tsen_offset) / 7.753;
+        temp = (((float)v0 - (float)v1) - (float)tsen_offset) / 7.753f;
     } else {
-        temp = (((float)v1 - (float)v0) - (float)tsen_offset) / 7.753;
+        temp = (((float)v1 - (float)v0) - (float)tsen_offset) / 7.753f;
     }
 
     return temp;

--- a/drivers/soc/bl702/std/include/bl702_glb.h
+++ b/drivers/soc/bl702/std/include/bl702_glb.h
@@ -749,8 +749,8 @@ BL_Err_Type GLB_Set_SPI_0_ACT_MOD_Sel(GLB_SPI_PAD_ACT_AS_Type mod);
 BL_Err_Type GLB_Select_Internal_Flash(void);
 BL_Err_Type GLB_Select_External_Flash(void);
 BL_Err_Type GLB_Deswap_Flash_Pin(void);
-BL_Err_Type GLB_Swap_Flash_CS_IO2_Pin();
-BL_Err_Type GLB_Swap_Flash_IO0_IO3_Pin();
+BL_Err_Type GLB_Swap_Flash_CS_IO2_Pin(void);
+BL_Err_Type GLB_Swap_Flash_IO0_IO3_Pin(void);
 BL_Err_Type GLB_Swap_Flash_Pin(void);
 BL_Err_Type GLB_Select_Internal_PSram(void);
 /*----------*/

--- a/drivers/soc/bl702/std/include/bl702_hbn.h
+++ b/drivers/soc/bl702/std/include/bl702_hbn.h
@@ -497,7 +497,9 @@ BL_Err_Type HBN_Set_Ldo11rt_Drive_Strength(HBN_LDO11RT_DRIVE_STRENGTH_Type stren
 BL_Err_Type HBN_32K_Sel(HBN_32K_CLK_Type clkType);
 BL_Err_Type HBN_Set_UART_CLK_Sel(HBN_UART_CLK_Type clkSel);
 BL_Err_Type HBN_Set_XCLK_CLK_Sel(HBN_XCLK_CLK_Type xClk);
+HBN_XCLK_CLK_Type HBN_Get_XCLK_CLK_Sel(void);
 BL_Err_Type HBN_Set_ROOT_CLK_Sel(HBN_ROOT_CLK_Type rootClk);
+HBN_ROOT_CLK_Type HBN_Get_ROOT_CLK_Sel(void);
 /*----------*/
 BL_Err_Type HBN_Set_HRAM_slp(void);
 BL_Err_Type HBN_Set_HRAM_Ret(void);

--- a/drivers/soc/bl702/std/src/bl702_clock.c
+++ b/drivers/soc/bl702/std/src/bl702_clock.c
@@ -203,7 +203,7 @@ static inline uint8_t Clock_Get_F32k_Sel_Val(void)
     return BL_GET_REG_BITS_VAL(tmpVal, HBN_F32K_SEL);
 }
 
-static inline uint32_t Clock_Get_AUPLL_Output()
+static inline uint32_t Clock_Get_AUPLL_Output(void)
 {
     uint32_t tmpVal = 0;
 
@@ -322,7 +322,7 @@ static inline uint8_t Clock_Get_SPI_Div_Val(void)
     return BL_GET_REG_BITS_VAL(tmpVal, GLB_SPI_CLK_DIV);
 }
 
-static inline uint32_t Clock_I2C_Clk_Mux_Output()
+static inline uint32_t Clock_I2C_Clk_Mux_Output(void)
 {
     /* pbclk */
     return Clock_System_Clock_Get(BL_SYSTEM_CLOCK_BCLK);

--- a/drivers/soc/bl702/std/src/bl702_glb.c
+++ b/drivers/soc/bl702/std/src/bl702_glb.c
@@ -150,6 +150,7 @@ GLB_ROOT_CLK_Type ATTR_CLOCK_SECTION GLB_Get_Root_CLK_Sel(void)
  * @return SUCCESS or ERROR
  *
 *******************************************************************************/
+#ifndef BFLB_USE_ROM_DRIVER
 BL_Err_Type ATTR_CLOCK_SECTION GLB_Set_System_CLK_Div(uint8_t hclkDiv, uint8_t bclkDiv)
 {
     /***********************************************************************************/
@@ -177,6 +178,7 @@ BL_Err_Type ATTR_CLOCK_SECTION GLB_Set_System_CLK_Div(uint8_t hclkDiv, uint8_t b
 
     return SUCCESS;
 }
+#endif
 
 /****************************************************************************/ /**
  * @brief  Get Bus clock divider

--- a/drivers/soc/bl702/std/src/bl702_hbn.c
+++ b/drivers/soc/bl702/std/src/bl702_hbn.c
@@ -836,6 +836,32 @@ BL_Err_Type HBN_Set_XCLK_CLK_Sel(HBN_XCLK_CLK_Type xClk)
 }
 
 /****************************************************************************/ /**
+ * @brief  Get current HBN xclk clock type selection
+ *
+ * @return current HBN xclk clock type selection
+ *
+*******************************************************************************/
+HBN_XCLK_CLK_Type ATTR_CLOCK_SECTION HBN_Get_XCLK_CLK_Sel(void)
+{
+    uint32_t tmpVal;
+    uint32_t tmpVal2;
+
+    tmpVal = BL_RD_REG(HBN_BASE, HBN_GLB);
+    tmpVal2 = BL_GET_REG_BITS_VAL(tmpVal, HBN_ROOT_CLK_SEL);
+
+    switch (tmpVal2 & 0x1) {
+        case 0x0:
+            return HBN_XCLK_CLK_RC32M;
+
+        case 0x1:
+            return HBN_XCLK_CLK_XTAL;
+
+        default:
+            return -1;
+    }
+}
+
+/****************************************************************************/ /**
  * @brief  Select root clk source
  *
  * @param  rootClk: root clock type selection
@@ -879,6 +905,36 @@ BL_Err_Type ATTR_CLOCK_SECTION HBN_Set_ROOT_CLK_Sel(HBN_ROOT_CLK_Type rootClk)
     return SUCCESS;
 }
 #endif
+
+/****************************************************************************/ /**
+ * @brief  Get current HBN root clk source
+ *
+ * @return current HBN root clock selection
+ *
+*******************************************************************************/
+HBN_ROOT_CLK_Type ATTR_CLOCK_SECTION HBN_Get_ROOT_CLK_Sel(void)
+{
+    uint32_t tmpVal;
+    uint32_t tmpVal2;
+
+    tmpVal = BL_RD_REG(HBN_BASE, HBN_GLB);
+    tmpVal2 = BL_GET_REG_BITS_VAL(tmpVal, HBN_ROOT_CLK_SEL);
+
+    switch (tmpVal2) {
+        case 0x0:
+            return HBN_ROOT_CLK_RC32M;
+
+        case 0x1:
+            return HBN_ROOT_CLK_XTAL;
+
+        case 0x02:
+        case 0x03:
+            return HBN_ROOT_CLK_DLL;
+
+        default:
+            return -1;
+    }
+}
 
 /****************************************************************************/ /**
  * @brief  set HBN_RAM sleep mode

--- a/drivers/soc/bl702/std/src/bl702_romapi.c
+++ b/drivers/soc/bl702/std/src/bl702_romapi.c
@@ -107,14 +107,14 @@ __ALWAYS_INLINE ATTR_CLOCK_SECTION
 {
     return RomDriver_GLB_Get_Root_CLK_Sel();
 }
-#if 0
+
 __ALWAYS_INLINE ATTR_CLOCK_SECTION
     BL_Err_Type
     GLB_Set_System_CLK_Div(uint8_t hclkDiv, uint8_t bclkDiv)
 {
     return RomDriver_GLB_Set_System_CLK_Div(hclkDiv, bclkDiv);
 }
-#endif
+
 __ALWAYS_INLINE ATTR_CLOCK_SECTION
     uint8_t
     GLB_Get_BCLK_Div(void)

--- a/drivers/soc/bl702/std/startup/start.S
+++ b/drivers/soc/bl702/std/startup/start.S
@@ -68,11 +68,14 @@ __start:
 #endif
 
     /* Check for an initialization routine and call it if one exists, otherwise
-     * just skip over the call entirely.   Note that __metal_initialize isn't
-     * actually a full C function, as it doesn't end up with the .bss or .data
-     * segments having been initialized.  This is done to avoid putting a
-     * burden on systems that can be initialized without having a C environment
-     * set up. */
+     * just skip over the call entirely. */
+    .weak __metal_before_start
+    la ra, __metal_before_start
+    beqz ra, 1f
+    jalr ra
+1:
+
+    /* Call Bouffalolab system initialization routine */
     jal SystemInit
 
     /* start load code to itcm like. */

--- a/drivers/soc/bl702/std/startup/system_bl702.c
+++ b/drivers/soc/bl702/std/startup/system_bl702.c
@@ -27,7 +27,7 @@
 
 void SystemInit(void)
 {
-    uint32_t *p;
+    uint8_t *p;
     uint8_t i;
     uint32_t tmpVal = 0;
     uint8_t flashCfg = 0;
@@ -57,13 +57,13 @@ void SystemInit(void)
     BL_WR_REG(GLB_BASE, GLB_PARM, tmpVal);
 
     /* CLear all interrupt */
-    p = (uint32_t *)(CLIC_HART0_BASE + CLIC_INTIE_OFFSET);
+    p = (uint8_t *)(CLIC_HART0_BASE + CLIC_INTIE_OFFSET);
 
     for (i = 0; i < (IRQn_LAST + 3) / 4; i++) {
         p[i] = 0;
     }
 
-    p = (uint32_t *)(CLIC_HART0_BASE + CLIC_INTIP_OFFSET);
+    p = (uint8_t *)(CLIC_HART0_BASE + CLIC_INTIP_OFFSET);
 
     for (i = 0; i < (IRQn_LAST + 3) / 4; i++) {
         p[i] = 0;


### PR DESCRIPTION
Hello,

He have got lot of issues with recent bouffalo_sdk for BL702 MCU especially with EFUSE support, clocking, USB, ADC and compilation warnings.  This issues were fixed and extensively tested on custom BL702 board and with XT-ZB1 evaluation board.
Please, make review and pull changes to upstream SDK version (v2.0).