### PR TITLE
[fix][dma] fix index in dma2_isr for dma_callback

### DIFF
--- a/drivers/lhal/src/bflb_dma.c
+++ b/drivers/lhal/src/bflb_dma.c
@@ -59,7 +59,7 @@ void dma2_isr(int irq, void *arg)
 
     for (uint8_t i = 0; i < 8; i++) {
         if (regval & (1 << i)) {
-            dma_callback[1][i].handler(dma_callback[2][i].arg);
+            dma_callback[2][i].handler(dma_callback[2][i].arg);
         }
     }
 }


### PR DESCRIPTION
Interrupt handeling for DMA2 on D0 ether crashes with 'Instruction access fault' or does not get handled at all. (Depends on the used bflb_device_s.idx value.)

With this patch this will be fixed. Also I had to reset the chip to recover and could than observe the expected behaviour.

For testing I used this device structure
```c
struct bflb_device_s dev_desc_dma2_ch0 = {
    .name = "dma2_ch0",
    .reg_base = DMA2_BASE + 1 * DMA_CHANNEL_OFFSET,
    .irq_num = DMA2_INT0_IRQn,
    .idx = 2,
    .sub_idx = 0,
    .dev_type = BFLB_DEVICE_TYPE_DMA,
    .user_data = NULL
};
```