### PR TITLE
add ft232hq support

### DIFF
--- a/tools/openocd/interface/ft232h.cfg
+++ b/tools/openocd/interface/ft232h.cfg
@@ -1,0 +1,23 @@
+# tested on FT232HQ generic cheap purple adapter
+# TCK:  D0
+# TDI:  D1
+# TDO:  D2
+# TMS:  D3
+# TRST: D4
+# SRST: D5
+
+
+adapter driver ftdi
+ftdi vid_pid 0x0403 0x6014
+
+ftdi tdo_sample_edge falling
+transport select jtag
+
+ftdi channel 0
+
+ftdi layout_init 0x0078 0x017b
+
+ftdi layout_signal nTRST -ndata 0x0010 -noe 0x0040
+ftdi layout_signal nSRST -ndata 0x0020 -noe 0x0040
+
+adapter speed 100


### PR DESCRIPTION
Hello, this adds support for FT232H and FT232HQ adapters for openOCD.

It works with mine which is this model: https://user-images.githubusercontent.com/1549028/219136649-b83fe1e2-26ae-417c-9f38-46d55629f4f6.jpg
https://aliexpress.com/item/1005006112448661.html
which is a fairly common cheaper option than the bl702 adapter or ft2232 series.